### PR TITLE
CMVS-PMVS 일부 파일 오타 수정 및 meshclean에서 confidence 비활성화

### DIFF
--- a/elibs/CMVS-PMVS/base/pmvs/patchOrganizerS.cc
+++ b/elibs/CMVS-PMVS/base/pmvs/patchOrganizerS.cc
@@ -710,7 +710,7 @@ void CpatchOrganizerS::writePLY(const std::vector<Ppatch>& patches,
        << "property uchar green" << '\n'
        << "property uchar blue" << '\n'
        << "property uchar alpha" << '\n'
-       << "elenment face 0" << '\n'
+       << "element face 0" << '\n'
        << "property list uchar int vertex_indices" << '\n'
        << "end_header" << '\n';
 
@@ -805,7 +805,7 @@ void CpatchOrganizerS::writePLY(const std::vector<Ppatch>& patches,
        << "property uchar green" << '\n'
        << "property uchar blue" << '\n'
        << "property uchar alpha" << '\n'
-       << "elenment face 0" << '\n'
+       << "element face 0" << '\n'
        << "property list uchar int vertex_indices" << '\n'
        << "end_header" << '\n';
 

--- a/elibs/CMVS-PMVS/base/stann/CMakeLists.txt
+++ b/elibs/CMVS-PMVS/base/stann/CMakeLists.txt
@@ -6,7 +6,7 @@ dpoint.hpp
 pair_iter.hpp
 qknn.hpp
 rand.hpp
-sep_float.hp
+sep_float.hpp
 sfcnn.hpp
 sfcnn_knng.hpp
 zorder_lt.hpp

--- a/elibs/mve-master/apps/meshclean/meshclean.cc
+++ b/elibs/mve-master/apps/meshclean/meshclean.cc
@@ -28,7 +28,7 @@ struct AppSettings
     bool delete_scale = false;
     bool delete_conf = false;
     bool delete_colors = false;
-    float conf_threshold = 1.0f;
+    float conf_threshold = 0.0f;
     float conf_percentile = -1.0f;
     int component_size = 1000;
 };


### PR DESCRIPTION
## 파일 오타 수정
- CMVS-PMVS/base/pmvs/patchOrganizerS.cc
- CMVS-PMVS/base/stann/CMakeLists.txt
## AppSettings.conf_threshold 기본 값 변경을 통한 confidence 비활성화
* command line 입력 전/후 비교:
  * AppSettings.conf_threshold(=1.0f): ./meshclean **-t0** -c30000 mesh.ply mesh-clean.ply
  * AppSettings.conf_threshold(=0.0f): ./meshclean -c30000 mesh.ply mesh-clean.ply
  * (option) -t, --threshold=ARG: threshold on the geometry confidence
  * (option) -c, --component-size=ARG: minimum number of vertices per component
* PoissonRecon의 결과물(.ply)에는 confidence 정보가 없으므로 meshclean을 활용하기 위해서는 meshclean의 confidence 정보 비활성화

